### PR TITLE
Get spells/debuffs cast by pets working

### DIFF
--- a/AethysCore/Class/Spell.lua
+++ b/AethysCore/Class/Spell.lua
@@ -124,10 +124,14 @@
     end
 
     -- Check if the spell Is Available or not.
-    function Spell:IsAvailable ()
+    function Spell:IsAvailable (CheckPet)
       if not Cache.SpellInfo[self.SpellID] then Cache.SpellInfo[self.SpellID] = {}; end
       if Cache.SpellInfo[self.SpellID].IsAvailable == nil then
-        Cache.SpellInfo[self.SpellID].IsAvailable = IsPlayerSpell(self.SpellID);
+		if CheckPet == true then
+			Cache.SpellInfo[self.SpellID].IsAvailable = IsSpellKnown(self.SpellID, true );
+		else
+			Cache.SpellInfo[self.SpellID].IsAvailable = IsPlayerSpell(self.SpellID);
+		end
       end
       return Cache.SpellInfo[self.SpellID].IsAvailable;
     end
@@ -175,9 +179,9 @@
         for i = 1, NumPetSpells do
           CurrentSpellID = select(7, GetSpellInfo(i, BOOKTYPE_PET))
           if CurrentSpellID then
-            CurrentSpell = Spell(CurrentSpellID);
-            if CurrentSpell:IsAvailable() and (CurrentSpell:IsKnown() or IsTalentSpell(i, BOOKTYPE_PET)) then
-              if not BlankScan then
+            CurrentSpell = Spell(CurrentSpellID, "Pet");
+            if CurrentSpell:IsAvailable(true) and (CurrentSpell:IsKnown( true ) or IsTalentSpell(i, BOOKTYPE_PET)) then
+			  if not BlankScan then
                 Cache.Persistent.SpellLearned.Pet[CurrentSpell:ID()] = true;
               end
             end

--- a/AethysCore/Class/Unit.lua
+++ b/AethysCore/Class/Unit.lua
@@ -7,6 +7,7 @@
   local Unit = AC.Unit;
   local Player = Unit.Player;
   local Target = Unit.Target;
+  local Pet = Unit.Pet;
   local Spell = AC.Spell;
   local Item = AC.Item;
   -- Lua
@@ -519,7 +520,7 @@
       local unitInfo = Cache.UnitInfo[GUID]
       for i = 1, #unitInfo.Debuffs do
         if Spell:ID() == unitInfo.Debuffs[i][11] then
-          if AnyCaster or (unitInfo.Debuffs[i][8] and Player:IsUnit(Unit(unitInfo.Debuffs[i][8]))) then
+          if AnyCaster or (unitInfo.Debuffs[i][8] and (Player:IsUnit(Unit(unitInfo.Debuffs[i][8])) or Pet:IsUnit(Unit(unitInfo.Debuffs[i][8])))) then
             if Index then
               return unitInfo.Debuffs[i][Index];
             else


### PR DESCRIPTION
Abilities cast by pets were not working correctly as they were not getting cached (IsPlayerSpell in IsAvailable will return false even if learned as they are pet spells). Add a flag so when scanning the pet spellbook we use IsSpellKnown instead. Additionally while IsKnown already supported checking pets when you were checking the pet spellbook you were still using the player version of IsKnown instead of the pet one.

When checking debuffs checking our own pets is sometimes needed. Probably fine to just check pets as well as yourself in those cases but you could change over to a checkPet flag or something if inclined.

In particular the mage module needs to be able to check if their own pet is debuffing the enemy with water jet which was unable to be done in the old style (AnyUnit would allow matches to PartyPet<x> as well  which would not work as you can not use other mages waterjet...and without the flag you will never return the debuff as your pet is casting it not you).