### PR TITLE
Update KeyBinding.lua

### DIFF
--- a/AethysCore/Events/KeyBinding.lua
+++ b/AethysCore/Events/KeyBinding.lua
@@ -36,7 +36,8 @@
       ["DIVIDE"] = "/",
       ["MINUS"] = "-",
       ["MULTIPLY"] = "*",
-      ["PLUS"] = "+"
+      ["PLUS"] = "+",
+      ["BUTTON"] = "M"
     };
     local function ShortenKB (KeyBinding)
       for Pattern, Replace in pairs ( ShortKBSubString ) do


### PR DESCRIPTION
I believe only the mouse buttons are referred to as BUTTON#, this would prevent showing the keybinding for an action bound to a mouse key as BUTTON#, [example](https://i.imgur.com/pUS1EI7.png).