### PR TITLE
Fixes ACTIONBUTTON12

### DIFF
--- a/HeroLib/Events/Action.lua
+++ b/HeroLib/Events/Action.lua
@@ -107,10 +107,11 @@ local ButtonByAddOn = {
 } -- { [AddOn] = { [BarIndex] = { [1] = ButtonBaseName, [2] = CommandNameFormat } } }
 
 local function GetBarInfo(ActionSlot)
-  local PreviousBarIndex = mathfloor(ActionSlot / 12)
   local BarIndex = mathceil(ActionSlot / 12)
-  local ActionSlotOffset = PreviousBarIndex * 12
-  local BarSlot = ActionSlot - ActionSlotOffset
+  local BarSlot = ActionSlot % 12
+  if BarSlot == 0 then
+    BarSlot = 12
+  end
 
   return BarIndex, BarSlot
 end


### PR DESCRIPTION
GetBarInfo returned for the call `GetBarInfo(12)` the values `1, 0` instead of `1, 12` before this patch.