### PR TITLE
Fix child panel naming clashes

### DIFF
--- a/HeroLib/GUI/Panels.lua
+++ b/HeroLib/GUI/Panels.lua
@@ -66,12 +66,12 @@ local function CreateCheckButton(Parent, Setting, Text, Tooltip, Optionals)
   CheckButton.SavedVariablesTable, CheckButton.SavedVariablesKey = Parent.SavedVariablesTable, Setting
 
   -- Frame init
-  if not LastOptionAttached[Parent.name] then
+  if not LastOptionAttached[Parent.usedName] then
     CheckButton:SetPoint("TOPLEFT", 15, -10)
   else
-    CheckButton:SetPoint("TOPLEFT", LastOptionAttached[Parent.name][1], "BOTTOMLEFT", LastOptionAttached[Parent.name][2], LastOptionAttached[Parent.name][3])
+    CheckButton:SetPoint("TOPLEFT", LastOptionAttached[Parent.usedName][1], "BOTTOMLEFT", LastOptionAttached[Parent.usedName][2], LastOptionAttached[Parent.usedName][3])
   end
-  LastOptionAttached[Parent.name] = { CheckButton, 0, 0 }
+  LastOptionAttached[Parent.usedName] = { CheckButton, 0, 0 }
 
   CheckButton:SetChecked(CheckButton.SettingTable[CheckButton.SettingKey])
 
@@ -120,12 +120,12 @@ local function CreateDropdown(Parent, Setting, Values, Text, Tooltip, Optionals)
   end
 
   -- Frame init
-  if not LastOptionAttached[Parent.name] then
+  if not LastOptionAttached[Parent.usedName] then
     Dropdown:SetPoint("TOPLEFT", 0, -30)
   else
-    Dropdown:SetPoint("TOPLEFT", LastOptionAttached[Parent.name][1], "BOTTOMLEFT", LastOptionAttached[Parent.name][2] - 15, LastOptionAttached[Parent.name][3] - 20)
+    Dropdown:SetPoint("TOPLEFT", LastOptionAttached[Parent.usedName][1], "BOTTOMLEFT", LastOptionAttached[Parent.usedName][2] - 15, LastOptionAttached[Parent.usedName][3] - 20)
   end
-  LastOptionAttached[Parent.name] = { Dropdown, 15, 0 }
+  LastOptionAttached[Parent.usedName] = { Dropdown, 15, 0 }
 
   local function Initialize(Self, Level)
     local Info = UIDropDownMenu_CreateInfo()
@@ -161,12 +161,12 @@ local function CreateSlider(Parent, Setting, Values, Text, Tooltip, Action, Opti
   Slider.SavedVariablesTable, Slider.SavedVariablesKey = Parent.SavedVariablesTable, Setting
 
   -- Frame init
-  if not LastOptionAttached[Parent.name] then
+  if not LastOptionAttached[Parent.usedName] then
     Slider:SetPoint("TOPLEFT", 20, -25)
   else
-    Slider:SetPoint("TOPLEFT", LastOptionAttached[Parent.name][1], "BOTTOMLEFT", LastOptionAttached[Parent.name][2] + 5, LastOptionAttached[Parent.name][3] - 20)
+    Slider:SetPoint("TOPLEFT", LastOptionAttached[Parent.usedName][1], "BOTTOMLEFT", LastOptionAttached[Parent.usedName][2] + 5, LastOptionAttached[Parent.usedName][3] - 20)
   end
-  LastOptionAttached[Parent.name] = { Slider, -5, -20 }
+  LastOptionAttached[Parent.usedName] = { Slider, -5, -20 }
 
   Slider:SetMinMaxValues(Values[1], Values[2])
   Slider.minValue, Slider.maxValue = Slider:GetMinMaxValues()
@@ -233,12 +233,12 @@ local function CreateButton(Parent, Setting, Text, Tooltip, Action, Width, Heigh
   end
 
   -- Frame init
-  if not LastOptionAttached[Parent.name] then
+  if not LastOptionAttached[Parent.usedName] then
     Button:SetPoint("TOPLEFT", 15, -10)
   else
-    Button:SetPoint("TOPLEFT", LastOptionAttached[Parent.name][1], "BOTTOMLEFT", LastOptionAttached[Parent.name][2], LastOptionAttached[Parent.name][3])
+    Button:SetPoint("TOPLEFT", LastOptionAttached[Parent.usedName][1], "BOTTOMLEFT", LastOptionAttached[Parent.usedName][2], LastOptionAttached[Parent.usedName][3])
   end
-  LastOptionAttached[Parent.name] = { Button, 0, 0 }
+  LastOptionAttached[Parent.usedName] = { Button, 0, 0 }
 
   _G[Button:GetName() .. "Text"]:SetText("|c00dfb802" .. Text .. "|r")
 
@@ -284,7 +284,7 @@ function GUI.CreateChildPanel(Parent, CName)
   CP.SavedVariablesTable = Parent.SavedVariablesTable
   CP.name = CName
   CP.parent = Parent.name
-  CP.usedName = CName:gsub(" ", "")
+  CP.usedName = ParentName .. "_ChildPanel_" .. CName:gsub(" ", "")
   local category = Settings.RegisterCanvasLayoutSubcategory(Parent.category, CP, CName)
   Settings.RegisterAddOnCategory(category)
   CP.category = category


### PR DESCRIPTION
This pull request will fix naming conflicts for child panels.

This occurs, for example, when someone uses the HeroLib in a custom addon to create a menu with a "General" settings section. Now, when the user loads the custom addon and, for example, HeroRotation, both addons will try to create a child panel named "General", resulting in a name conflict since the panel will only use the name "General" to identify itself. Currently, this results in an empty "General" settings page in one of the addons (the first loaded addon wins).

Also, it can be reproduced when a class, for example DeathKnight, creates a child panel called "Cooldown" in the Frost and Unholy specs. And in this child panel, there is another child panel called "Defensives" where a slider for RuneTap or something is created. All the settings inside the "Defensives" child panel identify themselves with the name of the parent "Cooldown". This causes a problem when the settings for the second child panel are created. Therefore, only one of these "Defensives" panels is filled. The other one is empty.

In summary, the following is currently causing a problem: 
Scenario 1)
"CustomAddon -> General -> Custom Settings"
"HeroRotation -> General -> Custom Settings"
Since all custom settings identify their parent panel with the same name ("General").
The AddonName is ignored. However, this should not be the case.

Scenario 2)
"DeathKnight -> Frost -> Cooldown -> Defensives -> RuneTapSlider"
"DeathKnight -> Unholy -> Cooldown -> Defensives -> RuneTapSlider"
Because both "Defensives" panels are within a panel that is currently identified with the same name ("Cooldown").