### PR TITLE
Fix GetTime() usage in HL.Pulse function

### DIFF
--- a/HeroLib/Main.lua
+++ b/HeroLib/Main.lua
@@ -58,7 +58,7 @@ function HL.Pulse()
     end
     return
   end
-  if GetTime(true) > HL.Timer.Pulse and OnRetail then
+  if GetTime() > HL.Timer.Pulse and OnRetail then
     -- Put a 10ms min and 50ms max limiter to save FPS (depending on World Latency).
     -- And add the Reduce CPU Load offset (default 50ms) in case it's enabled.
     --HL.Timer.PulseOffset = mathmax(10, mathmin(50, HL.Latency()))/1000 + (HL.GUISettings.General.ReduceCPULoad and HL.GUISettings.General.ReduceCPULoadOffset or 0)


### PR DESCRIPTION
- Correction to an unintended argument (true) passed to GetTime() on line 62 of HL.Pulse.



I believe this should correct an unintended argument (true) passed to GetTime() on line 62 of HL.Pulse. From my understanding, GetTime() does not accept arguments, so this may have been a mistake or an oversight.

With this change, GetTime() is now called without arguments, aligning with the expected API usage. However, given the size of the WoW API and HeroLib, please let me know if there's any context I may have missed.