### PR TITLE
Cleanup API parameter usage in Player/Power.lua

### DIFF
--- a/HeroLib/Class/Unit/Player/Power.lua
+++ b/HeroLib/Class/Unit/Player/Power.lua
@@ -64,7 +64,7 @@ do
 
   -- mana.regen
   function Player:ManaRegen()
-    return GetPowerRegen(self.UnitID)
+    return GetPowerRegen()
   end
 
   -- Mana regen in a cast
@@ -171,7 +171,7 @@ do
 
   -- focus.regen
   function Player:FocusRegen()
-    return GetPowerRegen(self.UnitID)
+    return GetPowerRegen()
   end
 
   -- focus.pct
@@ -275,7 +275,7 @@ do
 
   -- energy.regen
   function Player:EnergyRegen()
-    return GetPowerRegen(self.UnitID)
+    return GetPowerRegen()
   end
 
   -- energy.pct
@@ -368,7 +368,7 @@ do
   end
 
   function Player:ChargedComboPoints()
-    local chargedCps = UnitPowerCharged(self.UnitID, ComboPointsPowerType, true)
+    local chargedCps = UnitPowerCharged(self.UnitID)
     return (chargedCps and #chargedCps) or 0
   end
 

--- a/HeroLib/Events/Player.lua
+++ b/HeroLib/Events/Player.lua
@@ -115,12 +115,14 @@ local function BookScan(BlankScan)
     -- Flyout Spells
     for i = 1, GetNumFlyouts() do
       local FlyoutID = GetFlyoutID(i)
-      local NumSlots, IsKnown = select(3, GetFlyoutInfo(FlyoutID))
-      if IsKnown and NumSlots > 0 then
-        for j = 1, NumSlots do
-          local CurrentSpellID, _, IsKnownSpell = GetFlyoutSlotInfo(FlyoutID, j)
-          if CurrentSpellID and IsKnownSpell then
-            SpellLearned[CurrentSpellID] = true
+      if FlyoutID then
+        local NumSlots, IsKnown = select(3, GetFlyoutInfo(FlyoutID))
+        if IsKnown and NumSlots > 0 then
+          for j = 1, NumSlots do
+            local CurrentSpellID, _, IsKnownSpell = GetFlyoutSlotInfo(FlyoutID, j)
+            if CurrentSpellID and IsKnownSpell then
+              SpellLearned[CurrentSpellID] = true
+            end
           end
         end
       end
@@ -190,7 +192,7 @@ HL:RegisterForEvent(
     Player:UpdateEquipment()
     local Equip = Player:GetEquipment()
     for i=1,16 do
-      if slot ~= 4 and not Equip[slot] then
+      if i ~= 4 and not Equip[i] then
         C_Timer.After(2, function()
             Player:UpdateEquipment()
           end
@@ -249,8 +251,10 @@ HL:RegisterForEvent(
                   local DefinitionID = TalentEntryInfo["definitionID"]
                   local DefinitionInfo = GetDefinitionInfo(DefinitionID)
                   local SpellID = DefinitionInfo["spellID"]
-                  local SpellName = GetSpellInfo(SpellID)
-                  Cache.Persistent.Talents[SpellID] = (Cache.Persistent.Talents[SpellID]) and (Cache.Persistent.Talents[SpellID] + TalentRank) or TalentRank
+                  if SpellID and TalentRank and TalentRank > 0 then
+                    local SpellName = GetSpellInfo(SpellID)
+                    Cache.Persistent.Talents[SpellID] = (Cache.Persistent.Talents[SpellID]) and (Cache.Persistent.Talents[SpellID] + TalentRank) or TalentRank
+                  end
                 end
               end
             end


### PR DESCRIPTION
- Removed unit ID parameter from GetPowerRegen() calls which doesn't accept any arguments.
- Removed extra parameters from UnitPowerCharged() which only accepts a unit ID parameter.