### PR TITLE
Fix SpellType handling, IsMelee variable reference, and update inventory types

### DIFF
--- a/HeroLib/Class/Main.lua
+++ b/HeroLib/Class/Main.lua
@@ -139,11 +139,11 @@ do
       local SpellData = GetSpellInfo(SpellID)
       if not SpellData then return end
       self.SpellID = SpellData.spellID
-      self.SpellType = SpellData.spellType or "Player" -- For Pet, put "Pet". Default is "Player". Related to HeroCache.Persistent.SpellLearned.
+      self.SpellType = SpellType or "Player" -- For Pet, put "Pet". Default is "Player". Related to HeroCache.Persistent.SpellLearned.
       self.SpellName = SpellData.name
       self.MinimumRange = SpellData.minRange
       self.MaximumRange = SpellData.maxRange
-      self.IsMelee = MinimumRange == 0 and MaximumRange == 0
+      self.IsMelee = self.MinimumRange == 0 and self.MaximumRange == 0
       -- Variables
       self.LastCastTime = 0
       self.LastDisplayTime = 0
@@ -189,8 +189,9 @@ end
 --- ======= ITEM =======
 do
   local ItemSlotTable = {
-    -- Source: http://wowwiki.wikia.com/wiki/ItemEquipLoc
+    -- Source: https://warcraft.wiki.gg/wiki/Enum.InventoryType
     [""] = nil, -- "" value is the value of ItemEquipLoc if not equippable
+    ["INVTYPE_NON_EQUIP_IGNORE"] = nil,
     ["INVTYPE_AMMO"] = { 0 },
     ["INVTYPE_HEAD"] = { 1 },
     ["INVTYPE_NECK"] = { 2 },
@@ -219,6 +220,12 @@ do
     ["INVTYPE_TABARD"] = { 19 },
     ["INVTYPE_BAG"] = { 20, 21, 22, 23 },
     ["INVTYPE_QUIVER"] = { 20, 21, 22, 23 },
+    ["INVTYPE_PROFESSION_TOOL"] = { 20, 23 },
+    ["INVTYPE_PROFESSION_GEAR"] = { 21, 22, 24, 25 },
+    ["INVTYPE_EQUIPABLESPELL_OFFENSIVE"] = nil,
+    ["INVTYPE_EQUIPABLESPELL_UTILITY"] = nil,
+    ["INVTYPE_EQUIPABLESPELL_DEFENSIVE"] = nil,
+    ["INVTYPE_EQUIPABLESPELL_WEAPON"] = nil,
   }
 
   local Item = Class()
@@ -237,7 +244,7 @@ do
     self.ItemMinLevel = ItemMinLevel
     self.ItemSlotIDs = ItemSlotIDs or ItemSlotTable[ItemEquipLoc]
     self.ItemUseSpell = DBC.ItemSpell[ItemID] and HL.Spell(DBC.ItemSpell[ItemID]) or nil
-    
+
     -- Variables
     self.LastDisplayTime = 0
     self.LastHitTime = 0


### PR DESCRIPTION
### Changelog:
- **Fixed Spell Type Reference:**  
  Removed the reference to `SpellData.spellType` since `C_Spell.GetSpellInfo` doesn’t return this field. It now defaults to `"Player"` as originally intended.

- **Resolved IsMelee Variable Issue:**  
  Fixed a bug where `IsMelee` was incorrectly referencing local variables `MinimumRange` and `MaximumRange`, which don’t exist. Updated it to use `self.MinimumRange` and `self.MaximumRange` instead.

- **Implemented Proper SpellType Handling:**  
  The code now correctly respects the `SpellType` parameter passed to `Spell:New`. If a `SpellType` is provided, it will use that value instead of defaulting to `"Player"`.

- **Updated ItemEquipLoc Documentation:**  
  - Replaced `ItemEquipLoc` with `Enum.InventoryType` in the doc link for clarity.  
  - Added support for new inventory types:  
    - `INVTYPE_NON_EQUIP_IGNORE`  
    - `INVTYPE_PROFESSION_TOOL`  
    - `INVTYPE_PROFESSION_GEAR`  
    - `INVTYPE_EQUIPABLESPELL_OFFENSIVE`  
    - `INVTYPE_EQUIPABLESPELL_UTILITY`  
    - `INVTYPE_EQUIPABLESPELL_DEFENSIVE`  
    - `INVTYPE_EQUIPABLESPELL_WEAPON`

Hey Cilraz, let me know if anything here is incorrect, I’m just looking to improve HeroLib. Thanks! 