### PR TITLE
fix(HeroLib\Class\Unit\TimeToDie.lua): Correct TTD cache indexing

### DIFF
--- a/HeroLib/Class/Unit/TimeToDie.lua
+++ b/HeroLib/Class/Unit/TimeToDie.lua
@@ -97,8 +97,8 @@ function HL.TTDRefresh()
             tableinsert(Values, 1, Value)
             local n = #Values
             -- Delete values that are no longer valid
-            while (n > HistoryCount) or (Time - Values[n][1] > HistoryTime) do
-              TTDCache[#Cache + 1] = Values[n]
+            while n > 0 and ((n > HistoryCount) or (Time - Values[n][1] > HistoryTime)) do
+              TTDCache[#TTDCache + 1] = Values[n]
               Values[n] = nil
               n = n - 1
             end
@@ -155,7 +155,9 @@ function Unit:TimeToX(Percentage, MinSamples)
         Ey = Ey + y
       end
       -- Invariant to find matrix inverse
-      local Invariant = 1 / (Ex2 * n - Ex * Ex)
+      local denominator = Ex2 * n - Ex * Ex
+      if denominator == 0 then return 8888 end
+      local Invariant = 1 / denominator
       -- Solve for a and b
       a = (-Ex * Exy * Invariant) + (Ex2 * Ey * Invariant)
       b = (n * Exy * Invariant) - (Ex * Ey * Invariant)


### PR DESCRIPTION
- Changed TTDCache[#Cache + 1] to TTDCache[#TTDCache + 1] to correctly use the local TTD cache pool.
- Added a check n > 0 in the history cleanup loop to prevent accessing Values[0].
- Added a check for division by zero in Unit:TimeToX when calculating the linear regression invariant.