### PR TITLE
fix(Class\Unit\Player\Enemies): Ensure correct unit instance

### DIFF
--- a/HeroLib/Class/Unit/Player/Enemies.lua
+++ b/HeroLib/Class/Unit/Player/Enemies.lua
@@ -74,7 +74,7 @@ do
         if #Radiuses >= 2 then tablesort(Radiuses, Utils.SortASC) end
         -- Take the closest range from the Radius and filter from it
         for _, ThisUnit in pairs(Enemies[Radiuses[1]]) do
-          if ThisUnit:IsInRange(Radius) then tableinsert(EnemiesTable, Unit) end
+          if ThisUnit:IsInRange(Radius) then tableinsert(EnemiesTable, ThisUnit) end
         end
 
         return EnemiesTable


### PR DESCRIPTION
I believe this change addresses a scenario where `Player:GetEnemiesInRange` might insert the `Unit` module instead of the actual `ThisUnit` object when filtering from a larger-radius cache.