### PR TITLE
feat(SplashEnemies): Warlock Splash Update

### DIFF
--- a/HeroLib/Class/Unit/Player/Enemies.lua
+++ b/HeroLib/Class/Unit/Player/Enemies.lua
@@ -74,7 +74,7 @@ do
         if #Radiuses >= 2 then tablesort(Radiuses, Utils.SortASC) end
         -- Take the closest range from the Radius and filter from it
         for _, ThisUnit in pairs(Enemies[Radiuses[1]]) do
-          if ThisUnit:IsInRange(Radius) then tableinsert(EnemiesTable, Unit) end
+          if ThisUnit:IsInRange(Radius) then tableinsert(EnemiesTable, ThisUnit) end
         end
 
         return EnemiesTable

--- a/HeroLib/Events/SplashEnemies.lua
+++ b/HeroLib/Events/SplashEnemies.lua
@@ -564,19 +564,17 @@ function Splash.RegisterNucleusAbilities()
   -- Warlock
   -- Affliction
   RegisterNucleusAbility("DirectDamage", 27285, 10)               -- Seed of Corruption (Explosion)
-  RegisterNucleusAbility("DirectDamage", 386997, 10)              -- Soul Rot
-  RegisterNucleusAbility("DirectDamage", 386931, 10)              -- Vile Taint (DoT ticks)
-  RegisterNucleusAbility("DirectDamage", 205246, 10)              -- Phantom Singularity (ticks)
+  RegisterNucleusAbility("DirectDamage", 386997, 8)               -- Soul Rot
   -- Demonology
   RegisterNucleusAbility("DirectDamage", 89753, 8)                -- Felstorm (Felguard damage)
   RegisterNucleusAbility("DirectDamage", 196278, 8)               -- Implosion (damage)
-  RegisterNucleusAbility("DirectDamage", 105174, 8)               -- Hand of Gul'dan (impact AoE)
+  RegisterNucleusAbility("DirectDamage", 86040, 8)                -- Hand of Gul'dan (damage AoE)
   -- Destruction
   RegisterNucleusAbility("GroundDirectDamage", 152108, 8)         -- Cataclysm
-  RegisterNucleusAbility("DirectDamage", 196448, 10)              -- Channel Demonfire (volley damage)
+  RegisterNucleusAbility("DirectDamage", 196448, 8)               -- Channel Demonfire (volley damage)
   RegisterNucleusAbility("GroundDirectDamage", 42223, 8)          -- Rain of Fire
   RegisterNucleusAbility("GroundDirectDamage", 22703, 10)         -- Infernal Awakening (summon impact)
-  RegisterNucleusAbility("DirectDamage", 20153, 8)                -- Immolation (Infernal aura pulses)
+  RegisterNucleusAbility("DirectDamage", 20153, 12)               -- Immolation (Infernal aura pulses)
 
   -- Warrior
   -- Commons

--- a/HeroLib/Events/SplashEnemies.lua
+++ b/HeroLib/Events/SplashEnemies.lua
@@ -562,22 +562,21 @@ function Splash.RegisterNucleusAbilities()
   -- Restoration
 
   -- Warlock
-  -- Afflication
-  RegisterNucleusAbility("DirectDamage", 27285, 10)               -- Seed Explosion
+  -- Affliction
+  RegisterNucleusAbility("DirectDamage", 27285, 10)               -- Seed of Corruption (Explosion)
   RegisterNucleusAbility("DirectDamage", 386997, 10)              -- Soul Rot
-  RegisterNucleusAbility("DirectDamage", 386931, 10)              -- Vile Taint
+  RegisterNucleusAbility("DirectDamage", 386931, 10)              -- Vile Taint (DoT ticks)
+  RegisterNucleusAbility("DirectDamage", 205246, 10)              -- Phantom Singularity (ticks)
   -- Demonology
-  RegisterNucleusAbility("DirectDamage", 89753, 8)                -- Felstorm (Felguard)
-  RegisterNucleusAbility("GroundDirectDamage", 386609, 8)         -- Guillotine's Fel Explosion
-  RegisterNucleusAbility("DirectDamage", 86040, 8)                -- Hand of Gul'dan
-  RegisterNucleusAbility("DirectDamage", 196278, 8)               -- Implosion
+  RegisterNucleusAbility("DirectDamage", 89753, 8)                -- Felstorm (Felguard damage)
+  RegisterNucleusAbility("DirectDamage", 196278, 8)               -- Implosion (damage)
+  RegisterNucleusAbility("DirectDamage", 105174, 8)               -- Hand of Gul'dan (impact AoE)
   -- Destruction
   RegisterNucleusAbility("GroundDirectDamage", 152108, 8)         -- Cataclysm
-  RegisterNucleusAbility("DirectDamage", 387547, 8)               -- Cry Havoc
-  --RegisterNucleusAbility("GroundMultipleDirectDamage", 42223, 8)  -- Rain of Fire
-  RegisterNucleusAbility("GroundDirectDamage", 42223, 8)          -- Rain of Fire (temp, since Destruction has very few AoEs)
-  RegisterNucleusAbility("GroundDirectDamage", 22703, 10)         -- Summon Infernal
-  RegisterNucleusAbility("DirectDamage", 20153, 12)               -- Infernal/Blasphemy AoE Immolation pulse (not working... minion vs pet issue?)
+  RegisterNucleusAbility("DirectDamage", 196448, 10)              -- Channel Demonfire (volley damage)
+  RegisterNucleusAbility("GroundDirectDamage", 42223, 8)          -- Rain of Fire
+  RegisterNucleusAbility("GroundDirectDamage", 22703, 10)         -- Infernal Awakening (summon impact)
+  RegisterNucleusAbility("DirectDamage", 20153, 8)                -- Immolation (Infernal aura pulses)
 
   -- Warrior
   -- Commons


### PR DESCRIPTION
Removed deprecated abilities (Guillotine's Fel Explosion, Cry Havoc), updated Hand of Gul'dan to impact ID 105174, added Phantom Singularity ticks and Channel Demonfire, corrected Immolation radius to 8y.