### PR TITLE
fix(TimeToDie): health comparison uses correct array index

### DIFF
--- a/HeroLib/Class/Unit/TimeToDie.lua
+++ b/HeroLib/Class/Unit/TimeToDie.lua
@@ -82,7 +82,7 @@ function HL.TTDRefresh()
           local Values = UnitTable[1]
           local Time = CurrentTime - UnitTable[2]
           -- Check if the % HP changed since the last check (or if there were none)
-          if not Values or HealthPercentage ~= Values[2] then
+          if not Values[1] or HealthPercentage ~= Values[1][2] then
             local Value
             local LastIndex = #TTDCache
             -- Check if we can re-use a table from the cache


### PR DESCRIPTION
Fixed health comparison to use the correct array element. Each `Values[n]` entry stores `{ Time, HealthPercentage }`, so the check now correctly references `Values[1][2]`.

Please review Cil.